### PR TITLE
fix syntaxer unable to find assertion

### DIFF
--- a/solutions/syntaxer.py
+++ b/solutions/syntaxer.py
@@ -97,7 +97,7 @@ for t in body.text.splitlines():
 assert_q = JAVA_LANGUAGE.query(f"""(assert_statement) @assert""")
 
 for node, t in assert_q.captures(body).items():
-    if t == "assert":
+    if node == "assert":
         break
 else:
     l.debug("Did not find any assertions")


### PR DESCRIPTION
syntaxer couldn't find assertion even though there were assertion, now fixed by replacing t with node